### PR TITLE
support for paste-inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,16 @@ object. For instance:
 
 In addition, `cP` is mapped to copy the current line directly.
 
-The sequence `cv` is mapped to paste the content of system clipboard to the
+The sequence `cov` is mapped to paste the content of system clipboard to the
 next line.
+
+The `cv` is mapped to paste the system clipboard content after cursor
+position.
 
 Clipboard Utilities
 -------------------
 
- - OSX     - `pbcopy` and `pbpaste`
+ - OS X    - `pbcopy` and `pbpaste`
  - Windows - `clip` and `paste`
  - Linux   - `xsel`
 

--- a/plugin/system_copy.vim
+++ b/plugin/system_copy.vim
@@ -7,6 +7,7 @@ let s:blockwise = 'blockwise visual'
 let s:visual = 'visual'
 let s:motion = 'motion'
 let s:linewise = 'linewise'
+let s:paste_inline = 'inline'
 let s:mac = 'mac'
 let s:windows = 'windows'
 let s:linux = 'linux'
@@ -26,9 +27,14 @@ function! s:system_copy(type, ...) abort
   echohl String | echon 'Copied to clipboard using: ' . command | echohl None
 endfunction
 
-function! s:system_paste() abort
+function! s:system_paste(type) abort
   let command = <SID>PasteCommandForCurrentOS()
-  put =system(command)
+  silent call setreg('"', system(command))
+  if a:type == s:paste_inline
+    silent exe "normal! \"\"gp"
+  else
+    silent put \"
+  endif
   echohl String | echon 'Pasted to vim using: ' . command | echohl None
 endfunction
 
@@ -90,7 +96,8 @@ endfunction
 xnoremap <silent> <Plug>SystemCopy :<C-U>call <SID>system_copy(visualmode(),visualmode() ==# 'V' ? 1 : 0)<CR>
 nnoremap <silent> <Plug>SystemCopy :<C-U>set opfunc=<SID>system_copy<CR>g@
 nnoremap <silent> <Plug>SystemCopyLine :<C-U>set opfunc=<SID>system_copy<Bar>exe 'norm! 'v:count1.'g@_'<CR>
-nnoremap <silent> <Plug>SystemPaste :<C-U>call <SID>system_paste()<CR>
+nnoremap <silent> <Plug>SystemPaste :<C-U>call <SID>system_paste('below')<CR>
+nnoremap <silent> <Plug>SystemPasteInline :<C-U>call <SID>system_paste('inline')<CR>
 
 if !hasmapto('<Plug>SystemCopy', 'n') || maparg('cp', 'n') ==# ''
   nmap cp <Plug>SystemCopy
@@ -104,8 +111,12 @@ if !hasmapto('<Plug>SystemCopyLine', 'n') || maparg('cP', 'n') ==# ''
   nmap cP <Plug>SystemCopyLine
 endif
 
-if !hasmapto('<Plug>SystemPaste', 'n') || maparg('cv', 'n') ==# ''
-  nmap cv <Plug>SystemPaste
+if !hasmapto('<Plug>SystemPasteInline', 'n') || maparg('cv', 'n') ==# ''
+  nmap cv <Plug>SystemPasteInline
+endif
+
+if !hasmapto('<Plug>SystemPaste', 'n') || maparg('cov', 'n') ==# ''
+  nmap cov <Plug>SystemPaste
 endif
 
 " vim:ts=2:sw=2:sts=2


### PR DESCRIPTION
This PR adds paste-inline functionality and changes default mapping for `<Plug>SystemPaste` to `cV` and replaces the original `cv` with `<Plug>SystemPasteInline`.
