### PR TITLE
Use wl-copy and wl-paste if running wayland on Linux

### DIFF
--- a/plugin/system_copy.vim
+++ b/plugin/system_copy.vim
@@ -71,7 +71,11 @@ function! s:CopyCommandForCurrentOS()
   elseif os == s:windows
     return 'clip'
   elseif os == s:linux
-    return 'xsel --clipboard --input'
+    if !empty($WAYLAND_DISPLAY)
+      return 'wl-copy'
+    else
+      return 'xsel --clipboard --input'
+    endif
   endif
 endfunction
 
@@ -85,7 +89,11 @@ function! s:PasteCommandForCurrentOS()
   elseif os == s:windows
     return 'paste'
   elseif os == s:linux
-    return 'xsel --clipboard --output'
+    if !empty($WAYLAND_DISPLAY)
+      return 'wl-paste'
+    else
+      return 'xsel --clipboard --output'
+    endif
   endif
 endfunction
 


### PR DESCRIPTION
`xsel` does not work in wayland sessions. `wl-copy` is the standard that should be used when a wayland desktop is detected.