### PR TITLE
Add support for system paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@ System copy provides a mapping to copy to the system clipboard using a motion
 or visual selection. It also provides a mapping for pasting from the system
 clipboard.
 
-The default mapping is `cp`, and can be followed by any motion or text
+The default mapping is `cp` for copying and `cv` for pasting, and can be followed by any motion or text
 object. For instance:
 
 - `cpiw` => copy word into system clipboard
 - `cpi'` => copy inside single quotes to system clipboard
+- `cvi'` => paste inside single quotes from system clipboard
 
 In addition, `cP` is mapped to copy the current line directly.
 
-The sequence `cv` is mapped to paste the content of system clipboard to the
+The sequence `cV` is mapped to paste the content of system clipboard to the
 next line.
 
 Clipboard Utilities
@@ -31,7 +32,7 @@ Clipboard Utilities
  - OSX     - `pbcopy` and `pbpaste`
  - Windows - `clip` and `paste`
  - Linux   - `xsel`
- 
+
  **Note:** `xsel` can be installed with `apt-get install xsel` if your system doesn't have it installed
 
 Options

--- a/plugin/system_copy.vim
+++ b/plugin/system_copy.vim
@@ -28,7 +28,25 @@ function! s:system_copy(type, ...) abort
   let @@ = unnamed
 endfunction
 
-function! s:system_paste() abort
+function! s:system_paste(type, ...) abort
+  let mode = <SID>resolve_mode(a:type, a:0)
+  let command = <SID>PasteCommandForCurrentOS()
+  let unnamed = @@
+  if mode == s:linewise
+    let lines = { 'start': line("'["), 'end': line("']") }
+    silent exe lines.start . "," . lines.end . "d"
+    silent exe "set paste | normal! O" . system(command)
+    silent exe "set nopaste"
+  elseif mode == s:visual || mode == s:blockwise
+    silent exe "normal! `<" . a:type . "`>c" . system(command)
+  else
+    silent exe "normal! `[v`]c" . system(command)
+  endif
+  echohl String | echon 'Pasted to clipboard using: ' . command | echohl None
+  let @@ = unnamed
+endfunction
+
+function! s:system_paste_line() abort
   let command = <SID>PasteCommandForCurrentOS()
   put =system(command)
   echohl String | echon 'Pasted to vim using: ' . command | echohl None
@@ -92,7 +110,9 @@ endfunction
 xnoremap <silent> <Plug>SystemCopy :<C-U>call <SID>system_copy(visualmode(),visualmode() ==# 'V' ? 1 : 0)<CR>
 nnoremap <silent> <Plug>SystemCopy :<C-U>set opfunc=<SID>system_copy<CR>g@
 nnoremap <silent> <Plug>SystemCopyLine :<C-U>set opfunc=<SID>system_copy<Bar>exe 'norm! 'v:count1.'g@_'<CR>
-nnoremap <silent> <Plug>SystemPaste :<C-U>call <SID>system_paste()<CR>
+xnoremap <silent> <Plug>SystemPaste :<C-U>call <SID>system_paste(visualmode(),visualmode() ==# 'V' ? 1 : 0)<CR>
+nnoremap <silent> <Plug>SystemPaste :<C-U>set opfunc=<SID>system_paste<CR>g@
+nnoremap <silent> <Plug>SystemPasteLine :<C-U>call <SID>system_paste_line()<CR>
 
 if !hasmapto('<Plug>SystemCopy', 'n') || maparg('cp', 'n') ==# ''
   nmap cp <Plug>SystemCopy
@@ -110,4 +130,11 @@ if !hasmapto('<Plug>SystemPaste', 'n') || maparg('cv', 'n') ==# ''
   nmap cv <Plug>SystemPaste
 endif
 
+if !hasmapto('<Plug>SystemPaste', 'v') || maparg('cv', 'v') ==# ''
+  xmap cv <Plug>SystemPaste
+endif
+
+if !hasmapto('<Plug>SystemPasteLine', 'n') || maparg('cV', 'n') ==# ''
+  nmap cV <Plug>SystemPasteLine
+endif
 " vim:ts=2:sw=2:sts=2


### PR DESCRIPTION
This pull request adds support for system paste like system copy using motion or visual selection. The default mapping is `cv` . This changes the original mapping of `cv` to `cV` and replaces the original `<Plug>SystemPaste` with `<Plug>SystemPasteLine`.

There is already a related pull request #5 but it seems that it does some delay. That's why I made this a while a go. I thought maybe It would be useful.