### PR TITLE
Update system_copy.vim

### DIFF
--- a/plugin/system_copy.vim
+++ b/plugin/system_copy.vim
@@ -108,7 +108,7 @@ function! s:PasteCommandForCurrentOS()
     return 'paste'
   elseif os == s:linux
     if !empty($WAYLAND_DISPLAY)
-      return 'wl-paste'
+      return 'wl-paste -n'
     else
       return 'xsel --clipboard --output'
     endif


### PR DESCRIPTION
wl-paste (used on wayland) automatically adds a new line character at the end of text.
Using wl-paste -n fixes this.