### PR TITLE
Proposal: Move into paste mode before pasting from system clipboard

### DIFF
--- a/plugin/system_copy.vim
+++ b/plugin/system_copy.vim
@@ -32,16 +32,17 @@ function! s:system_paste(type, ...) abort
   let mode = <SID>resolve_mode(a:type, a:0)
   let command = <SID>PasteCommandForCurrentOS()
   let unnamed = @@
+  silent exe "set paste"
   if mode == s:linewise
     let lines = { 'start': line("'["), 'end': line("']") }
     silent exe lines.start . "," . lines.end . "d"
-    silent exe "set paste | normal! O" . system(command)
-    silent exe "set nopaste"
+    silent exe "normal! O" . system(command)
   elseif mode == s:visual || mode == s:blockwise
     silent exe "normal! `<" . a:type . "`>c" . system(command)
   else
     silent exe "normal! `[v`]c" . system(command)
   endif
+  silent exe "set nopaste"
   echohl String | echon 'Pasted to clipboard using: ' . command | echohl None
   let @@ = unnamed
 endfunction


### PR DESCRIPTION
I would like to make this proposal. I have tested my changes with several of my common use cases. Core functionality works properly, there are some changes in behaviour which are expected.

I tried to search for earlier discussion regarding this in this repository's issues, but couldn't find anything. If this has already been discussed and rejected, please close this PR :bowing_man: 

## Proposal

Move into paste mode before pasting from the system clipboard

### Advantages

- Paste exactly what is in the clipboard without applying the rules of the current buffer's file type
    - Open a JSON file, enter
    ```json
    {
        "key": "value"
    }
    ```
    - Copy four lines of text where each line's first character is at column zero
    - Paste from visual mode: `Vcv` => The paste starts at the key column instead of starting at column 0 because of JSON filetype's rule related to the indentation of newlines
    - The same thing happens if you try to paste the multiline text using `cvi"` with cursor on `k` (Although, this doesn't look like a common or useful command)
- When pasting using `cv$`, first line of pasted text always appears on the same line, no matter how long
    - One common use case would be pasting the link to a document in Markdown text after the link name: `[link-name]: <cursor>` => Run `cv$` => Link too long? It will be moved to the next line.

### Disadvantages

- _Unsure_ I use only simple motions like `iw`, `w`, `i"` and `it`. Changing modes before pasting could break some specific behaviour that other users depend on.

## Related PRs

- #3 
- #24 

## Tests

I tested my changes on Ubuntu 18.04 LTS with recent versions of Vim and Neovim.

```sh
$ vim --version | head -2
VIM - Vi IMproved 8.1 (2018 May 18, compiled Aug 31 2019 11:32:55)
Included patches: 1-1949

$ nvim --version | head -2
NVIM v0.4.3
Build type: Debug
```