### PR TITLE
Paste for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Clipboard Utilities
 -------------------
 
  - OSX     - `pbcopy` and `pbpaste`
- - Windows - `clip` and `paste`
+ - Windows - `clip` and `powershell.exe -NoLogo -NoProfile -Noninteractive -Command "Get-Clipboard"`
  - Linux   - `xsel`
 
  **Note:** `xsel` can be installed with `apt-get install xsel` if your system doesn't have it installed

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Clipboard Utilities
  - Windows - `clip` and `powershell.exe -NoLogo -NoProfile -Noninteractive -Command "Get-Clipboard"`
  - Linux   - `xsel`
 
- **Note:** `xsel` can be installed with `apt-get install xsel` if your system doesn't have it installed
+ **Note:** 	
+ 	Linux - `xsel` can be installed with `apt-get install xsel` if your system doesn't have it installed
+	Windows - Needs powershell to be present.
 
 Options
 -------

--- a/plugin/system_copy.vim
+++ b/plugin/system_copy.vim
@@ -116,7 +116,7 @@ function! s:PasteCommandForCurrentOS()
   if os == s:mac
     return 'pbpaste'
   elseif os == s:windows
-    return 'paste'
+    return 'powershell.exe -NoLogo -NoProfile -Noninteractive -Command "Get-Clipboard"'
   elseif os == s:linux
     if !empty($WAYLAND_DISPLAY)
       return 'wl-paste -n'


### PR DESCRIPTION
'paste' doesn't work in windows, the below settings work in windows.

let g:system_copy#copy_command='clip'
let g:system_copy#paste_command='powershell.exe -NoLogo -NoProfile -Noninteractive -Command "Get-Clipboard"'