### PR TITLE
Add support for non-GUI Vim on Windows

### DIFF
--- a/plugin/system_copy.vim
+++ b/plugin/system_copy.vim
@@ -83,7 +83,7 @@ function! s:currentOS()
   let known_os = 'unknown'
   if has("gui_mac") || os ==? 'Darwin'
     let known_os = s:mac
-  elseif has("gui_win32") || os =~? 'cygwin' || os =~? 'MINGW'
+  elseif has("win32") || os =~? 'cygwin' || os =~? 'MINGW'
     let known_os = s:windows
   elseif os ==? 'Linux'
     let known_os = s:linux


### PR DESCRIPTION
Both non-GUI Vim and gVim will work fine on Windows now.