### PR TITLE
Modified Paste Behavior to keep consistent with native vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+Forked differences from main (christoomey version):
+===========
+paste now mimics native vim paste instead of whatever chris was using.
+removed all plugin bindings (since I didn't like them). Must now explicitly set in .vimrc
+personal .vimrc:
+```.vimrc
+nmap <leader>y <Plug>SystemCopy
+nmap <leader>yy <Plug>SystemCopyLine
+nmap <leader>Y <Plug>SystemCopyLine
+xmap <leader>y <Plug>SystemCopy
+xmap <leader>p <Plug>SystemPaste
+nmap <leader>p <Plug>SystemPaste
+nmap <leader>P <Plug>SystemPasteLine
+```
+
 System Copy
 ===========
 

--- a/plugin/system_copy.vim
+++ b/plugin/system_copy.vim
@@ -60,27 +60,16 @@ function! s:system_paste(type, ...) abort
     elseif mode == s:visual || mode == s:blockwise
       silent exe "normal! `<" . a:type . "`>c" . paste_content
     else
-      silent exe "normal! `[v`]c" . paste_content
+      let str_len = strcharlen(paste_content)-1
+			let multiline = strcharpart(paste_content, str_len, 1) == "\n"
+			let c = [{'p': 'a', 'P': 'i'},{'p': 'o', 'P': 'O'}][multiline]
+      silent exe "normal! " . c[a:type] . (multiline ? strcharpart(paste_content, 0, str_len) : paste_content)
     endif
     silent exe "set nopaste"
     if g:system_copy_silent == 0
       echohl String | echon 'Pasted to clipboard using: ' . command | echohl None
     endif
     let @@ = unnamed
-  endif
-endfunction
-
-function! s:system_paste_line() abort
-  let command = <SID>PasteCommandForCurrentOS()
-  silent let command_output = system(command)
-  if v:shell_error != 0
-    echoerr command_output
-  else
-    let paste_content = command_output
-    put =paste_content
-    if g:system_copy_silent == 0
-      echohl String | echon 'Pasted to vim using: ' . command | echohl None
-    endif
   endif
 endfunction
 
@@ -151,6 +140,6 @@ xnoremap <silent> <Plug>SystemCopy :<C-U>call <SID>system_copy(visualmode(),visu
 nnoremap <silent> <Plug>SystemCopy :<C-U>set opfunc=<SID>system_copy<CR>g@
 nnoremap <silent> <Plug>SystemCopyLine :<C-U>set opfunc=<SID>system_copy<Bar>exe 'norm! 'v:count1.'g@_'<CR>
 xnoremap <silent> <Plug>SystemPaste :<C-U>call <SID>system_paste(visualmode(),visualmode() ==# 'V' ? 1 : 0)<CR>
-nnoremap <silent> <Plug>SystemPaste :<C-U>set opfunc=<SID>system_paste<CR>g@
-nnoremap <silent> <Plug>SystemPasteLine :<C-U>call <SID>system_paste_line()<CR>
+nnoremap <silent> <Plug>SystemPaste :<C-U>call <SID>system_paste('p')<CR>
+nnoremap <silent> <Plug>SystemPasteLine :<C-U>call <SID>system_paste('P')<CR>
 " vim:ts=2:sw=2:sts=2

--- a/plugin/system_copy.vim
+++ b/plugin/system_copy.vim
@@ -153,28 +153,4 @@ nnoremap <silent> <Plug>SystemCopyLine :<C-U>set opfunc=<SID>system_copy<Bar>exe
 xnoremap <silent> <Plug>SystemPaste :<C-U>call <SID>system_paste(visualmode(),visualmode() ==# 'V' ? 1 : 0)<CR>
 nnoremap <silent> <Plug>SystemPaste :<C-U>set opfunc=<SID>system_paste<CR>g@
 nnoremap <silent> <Plug>SystemPasteLine :<C-U>call <SID>system_paste_line()<CR>
-
-if !hasmapto('<Plug>SystemCopy', 'n') || maparg('cp', 'n') ==# ''
-  nmap cp <Plug>SystemCopy
-endif
-
-if !hasmapto('<Plug>SystemCopy', 'v') || maparg('cp', 'v') ==# ''
-  xmap cp <Plug>SystemCopy
-endif
-
-if !hasmapto('<Plug>SystemCopyLine', 'n') || maparg('cP', 'n') ==# ''
-  nmap cP <Plug>SystemCopyLine
-endif
-
-if !hasmapto('<Plug>SystemPaste', 'n') || maparg('cv', 'n') ==# ''
-  nmap cv <Plug>SystemPaste
-endif
-
-if !hasmapto('<Plug>SystemPaste', 'v') || maparg('cv', 'v') ==# ''
-  xmap cv <Plug>SystemPaste
-endif
-
-if !hasmapto('<Plug>SystemPasteLine', 'n') || maparg('cV', 'n') ==# ''
-  nmap cV <Plug>SystemPasteLine
-endif
 " vim:ts=2:sw=2:sts=2


### PR DESCRIPTION
gitignore #52 docs/tags
new paste behavior mimics native vim (almost. cursor position lost on block pastes)
removed all bindings forcing user to set their own bindings if they want to use plugin. preferable over forcing c and p which can confuse some. 
another reason to force manual bindings is that vim-plug seems to load plugin before my bindings are set. so I get double bindings for each command. both before and after plug calls same behavior. removing plugin bindings solves this for me and I see other plugins that decided to force bindings for similar reasons. idk. don't care to keep hacking to find out. 