### PR TITLE
Change the OCS command name from OSCYankString to OSCYank

### DIFF
--- a/plugin/system_copy.vim
+++ b/plugin/system_copy.vim
@@ -30,8 +30,8 @@ function! s:system_copy(type, ...) abort
   silent let command_output = system(command, getreg('@'))
   if v:shell_error != 0
     " Fall back to call OSC52 copy
-    if exists("g:system_copy_enable_osc52") && g:system_copy_enable_osc52 > 0 && exists('*OSCYankString')
-      call OSCYankString(getreg('@'))
+    if exists("g:system_copy_enable_osc52") && g:system_copy_enable_osc52 > 0 && exists('*OSCYank')
+      call OSCYank(getreg('@'))
     else
       echoerr command_output
     endif


### PR DESCRIPTION
Seems like the command name was changed in `ojroques/vim-oscyank` plugin. Updated to use the new command name.

https://github.com/ojroques/vim-oscyank/blob/c37c9d98e8a0aed749624fa14a7ece7913cf34de/plugin/oscyank.vim#L128