### PR TITLE
Patched in FreeBSD Support

### DIFF
--- a/plugin/system_copy.vim
+++ b/plugin/system_copy.vim
@@ -104,6 +104,8 @@ function! s:currentOS()
     let known_os = s:windows
   elseif os ==? 'Linux'
     let known_os = s:linux
+  elseif os ==? 'FreeBSD'
+    let known_os = s:linux
   else
     exe "normal \<Esc>"
     throw "unknown OS: " . os


### PR DESCRIPTION
When I tried to use the plugin on FreeBSD it didn't work since it only detects: Windows, OSX, and Gnu/Linux. All I had to do was add in two lines to the `currentOS` function. 

```vim
elseif os ==? 'FreeBSD'
  let known_os = s:linux
``` 
You can just treat FreeBSD as Linux, since they're very much the same under the hood. 